### PR TITLE
Address validation fixed in Instant OPD form 

### DIFF
--- a/client/src/modules/OPD/Registration.jsx
+++ b/client/src/modules/OPD/Registration.jsx
@@ -43,7 +43,7 @@ function OPDRegistrationForm() {
     if (!formData.contact.match(/^\d{10}$/)) newErrors.contact = 'Contact number must be 10 digits';
     if (!formData.address.trim()) {
       newErrors.address = 'Address is required';
-    } else if (formData.address.trim().length < 10) {
+    } else if (formData.address.trim().length < 5) {
       newErrors.address = 'Address must be at least 5 characters long';
     }
     if (!formData.department) newErrors.department = 'Department is required';


### PR DESCRIPTION
Address validation fixed in Instant OPD form now it lets you submit the code if the address is more than 5 characters and display error when it is less than 5. Issue No #193 