### PR TITLE
bugfix/reload-on-btnClick

### DIFF
--- a/client/src/modules/Registration/StepOne.jsx
+++ b/client/src/modules/Registration/StepOne.jsx
@@ -70,7 +70,9 @@ function StepOne() {
     return newErrors;
   };
 
-  const handleContinue = () => {
+  const handleContinue = (e) => {
+    e.preventDefault();
+    
     const validationErrors = validateForm();
     if (Object.keys(validationErrors).length > 0) {
       setErrors((prev) => ({


### PR DESCRIPTION
fixes #372 

issue was, clicking on 'continue' btn in /register was reloading the page instead of sending the user to step two, I added `e.preventDefault()` to fix the reload.