### PR TITLE
Added Missing Footer on Lab Test Page

### DIFF
--- a/client/src/modules/LabTest/LabTest.jsx
+++ b/client/src/modules/LabTest/LabTest.jsx
@@ -15,6 +15,7 @@ import raImage from '../../assets/ra.png';
 import ecgImage from '../../assets/ecg.png';
 import usgImage from '../../assets/usg.png';
 import Navbar from '../common/Navbar';
+import Footer from '../common/Footer';
 import { mode } from '../../store/atom'; // Importing the atom for mode
 
 const LabTestMedipedia = () => {
@@ -220,6 +221,7 @@ const LabTestMedipedia = () => {
           </div>
         )}
       </div>
+      <Footer/>
     </>
   );
 };


### PR DESCRIPTION
Fixes #315 

Someone already added the Navbar on the lab page and on the blog page, so I added Footer on the lab test page.


https://github.com/user-attachments/assets/c1208728-de72-4ba1-ade5-c8255085ae22

