### PR TITLE
added  rate limiter to login api   issue #440

### DIFF
--- a/server/routes/auth/auth.js
+++ b/server/routes/auth/auth.js
@@ -1,11 +1,21 @@
 const express = require("express");
+const rateLimit = require("express-rate-limit"); 
 const {
   registerUser,
   loginUser,
 } = require("../../controllers/auth/authController.js");
 const router = express.Router();
 
+// Create a rate limiter for login requests
+const loginLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000, // 5 minutes
+  max: 5, 
+  message: {
+    message: "Too many login attempts from this IP, please try again after 5 minutes",
+  },
+});
+
 router.post("/register", registerUser);
-router.post("/login", loginUser);
+router.post("/login", loginLimiter, loginUser); 
 
 module.exports = router;


### PR DESCRIPTION
i have added an rate limiter to the login api which will restrict a specific ip address to make more than 5 request to login api 

it will:
prevent bots attack
reduce load on api

image:
![image](https://github.com/user-attachments/assets/33f0835d-38ab-4578-9cf7-b116bdc4924c)


**please add gssoc-ext and level2 label before merge**